### PR TITLE
Swagger 추가

### DIFF
--- a/IAteIt/build.gradle
+++ b/IAteIt/build.gradle
@@ -36,6 +36,8 @@ dependencies {
 
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+
 	implementation 'mysql:mysql-connector-java:8.0.23'
 	implementation 'com.h2database:h2'
 

--- a/IAteIt/src/main/java/com/bnomad/IAteIt/domain/block/controller/BlockController.java
+++ b/IAteIt/src/main/java/com/bnomad/IAteIt/domain/block/controller/BlockController.java
@@ -15,7 +15,7 @@ import static com.bnomad.IAteIt.global.result.ResultCode.*;
 @RestController
 @RequestMapping("/api/v1/block")
 @RequiredArgsConstructor
-public class BlockController {
+public class BlockController implements BlockControllerSwagger {
 
     private final BlockService blockService;
 

--- a/IAteIt/src/main/java/com/bnomad/IAteIt/domain/block/controller/BlockControllerSwagger.java
+++ b/IAteIt/src/main/java/com/bnomad/IAteIt/domain/block/controller/BlockControllerSwagger.java
@@ -1,0 +1,49 @@
+package com.bnomad.IAteIt.domain.block.controller;
+
+import com.bnomad.IAteIt.domain.block.entity.dto.BlockingMemberRequest;
+import com.bnomad.IAteIt.global.error.ErrorResponse;
+import com.bnomad.IAteIt.global.result.ResultResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+
+@Tag(name = "Block", description = "Block 관련 차단 목록 확인 / 차단 / 차단 해제")
+public interface BlockControllerSwagger {
+
+    @Operation(summary = "Block한 멤버 리스트 불러오기")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "Block한 멤버 리스트를 불러왔습니다.",
+                            content = @Content(schema = @Schema(implementation = ResultResponse.class)))
+            }
+    )
+    ResponseEntity<ResultResponse> blockedMemberList();
+
+    @Operation(summary = "Member Block하기")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "해당 id의 멤버를 Block 했습니다.",
+                            content = @Content(schema = @Schema(implementation = ResultResponse.class))),
+                    @ApiResponse(responseCode = "400", description = "해당 id의 멤버가 없습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
+    ResponseEntity<ResultResponse> blockMember(@RequestBody BlockingMemberRequest blockingMemberRequest);
+
+
+    @Operation(summary = "Member Block 해제하기")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "멤버를 Block 해제했습니다.",
+                            content = @Content(schema = @Schema(implementation = ResultResponse.class)))
+            }
+    )
+    ResponseEntity<ResultResponse> unblock(@RequestParam("blockedMemberId") Long blockedMemberId);
+
+}

--- a/IAteIt/src/main/java/com/bnomad/IAteIt/domain/comment/controller/CommentController.java
+++ b/IAteIt/src/main/java/com/bnomad/IAteIt/domain/comment/controller/CommentController.java
@@ -16,7 +16,7 @@ import static com.bnomad.IAteIt.global.result.ResultCode.*;
 @RestController
 @RequestMapping("/api/v1/comment")
 @RequiredArgsConstructor
-public class CommentController {
+public class CommentController implements CommentControllerSwagger {
 
     private final CommentService commentService;
 

--- a/IAteIt/src/main/java/com/bnomad/IAteIt/domain/comment/controller/CommentControllerSwagger.java
+++ b/IAteIt/src/main/java/com/bnomad/IAteIt/domain/comment/controller/CommentControllerSwagger.java
@@ -1,0 +1,60 @@
+package com.bnomad.IAteIt.domain.comment.controller;
+
+import com.bnomad.IAteIt.domain.comment.entity.dto.CommentCreateDto;
+import com.bnomad.IAteIt.domain.comment.entity.dto.CommentEditDto;
+import com.bnomad.IAteIt.global.error.ErrorResponse;
+import com.bnomad.IAteIt.global.result.ResultResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Comment", description = "Meal Comment 조회 / Comment 생성, 수정, 삭제")
+public interface CommentControllerSwagger {
+
+    @Operation(summary = "Meal Comment 리스트 불러오기")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "해당 Meal의 Comment 리스트를 불러왔습니다.",
+                            content = @Content(schema = @Schema(implementation = ResultResponse.class)))
+            }
+    )
+    ResponseEntity<ResultResponse> getMealComments(@RequestParam("mealId") Long mealId);
+
+    @Operation(summary = "Comment 생성하기")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "Comment를 생성했습니다.",
+                            content = @Content(schema = @Schema(implementation = ResultResponse.class))),
+                    @ApiResponse(responseCode = "400", description = "해당 id의 멤버가 없습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
+    ResponseEntity<ResultResponse> createComment(@RequestBody CommentCreateDto commentCreateDto);
+
+    @Operation(summary = "Comment 수정하기")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "Comment 수정에 성공했습니다.",
+                            content = @Content(schema = @Schema(implementation = ResultResponse.class))),
+                    @ApiResponse(responseCode = "400", description = "해당 id의 Comment가 없습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
+    ResponseEntity<ResultResponse> editComment(@RequestBody CommentEditDto commentEditDto);
+
+    @Operation(summary = "Comment 삭제하기")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "Comment를 삭제했습니다.",
+                            content = @Content(schema = @Schema(implementation = ResultResponse.class))),
+                    @ApiResponse(responseCode = "400", description = "해당 id의 Comment가 없습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
+    ResponseEntity<ResultResponse> deleteComment(@RequestParam("commentId") Long commentId);
+}

--- a/IAteIt/src/main/java/com/bnomad/IAteIt/domain/feed/controller/FeedController.java
+++ b/IAteIt/src/main/java/com/bnomad/IAteIt/domain/feed/controller/FeedController.java
@@ -18,7 +18,7 @@ import static com.bnomad.IAteIt.global.result.ResultCode.*;
 @RestController
 @RequestMapping("/api/v1/feed")
 @RequiredArgsConstructor
-public class FeedController {
+public class FeedController implements FeedControllerSwagger {
 
     private final FeedService feedService;
 

--- a/IAteIt/src/main/java/com/bnomad/IAteIt/domain/feed/controller/FeedControllerSwagger.java
+++ b/IAteIt/src/main/java/com/bnomad/IAteIt/domain/feed/controller/FeedControllerSwagger.java
@@ -17,8 +17,9 @@ public interface FeedControllerSwagger {
     @ApiResponses(
             value = {
                     @ApiResponse(responseCode = "200", description = "최근 Feed 가져오기에 성공했습니다.",
-                    content = @Content(contentSchema = @Schema(implementation = ResultResponse.class)))
-            })
+                            content = @Content(schema = @Schema(implementation = ResultResponse.class))),
+            }
+    )
     ResponseEntity<ResultResponse> getRecent(@RequestParam("page") int pageNum);
 
 }

--- a/IAteIt/src/main/java/com/bnomad/IAteIt/domain/feed/controller/FeedControllerSwagger.java
+++ b/IAteIt/src/main/java/com/bnomad/IAteIt/domain/feed/controller/FeedControllerSwagger.java
@@ -1,0 +1,24 @@
+package com.bnomad.IAteIt.domain.feed.controller;
+
+import com.bnomad.IAteIt.global.result.ResultResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "Feed", description = "최근 Feed 가져오기")
+public interface FeedControllerSwagger {
+
+    @Operation(summary = "최근 Feed 가져오기")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "최근 Feed 가져오기에 성공했습니다.",
+                    content = @Content(contentSchema = @Schema(implementation = ResultResponse.class)))
+            })
+    ResponseEntity<ResultResponse> getRecent(@RequestParam("page") int pageNum);
+
+}

--- a/IAteIt/src/main/java/com/bnomad/IAteIt/domain/meal/controller/MealController.java
+++ b/IAteIt/src/main/java/com/bnomad/IAteIt/domain/meal/controller/MealController.java
@@ -14,7 +14,7 @@ import static com.bnomad.IAteIt.global.result.ResultCode.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/meal")
-public class MealController {
+public class MealController implements MealControllerSwagger {
 
     private final MealService mealService;
 

--- a/IAteIt/src/main/java/com/bnomad/IAteIt/domain/meal/controller/MealControllerSwagger.java
+++ b/IAteIt/src/main/java/com/bnomad/IAteIt/domain/meal/controller/MealControllerSwagger.java
@@ -1,0 +1,54 @@
+package com.bnomad.IAteIt.domain.meal.controller;
+
+import com.bnomad.IAteIt.domain.meal.entity.dto.MealCreateDto;
+import com.bnomad.IAteIt.domain.meal.entity.dto.MealEditDto;
+import com.bnomad.IAteIt.global.error.ErrorResponse;
+import com.bnomad.IAteIt.global.result.ResultResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+
+@Tag(name = "Meal", description = "Meal 생성 / 수정 / 삭제")
+public interface MealControllerSwagger {
+
+    @Operation(summary = "Meal 생성하기")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "Meal 생성에 성공했습니다.",
+                            content = @Content(schema = @Schema(implementation = ResultResponse.class))),
+                    @ApiResponse(responseCode = "400", description = "Meal 이미지가 없습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "400", description = "해당 멤버의 id가 없습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            }
+    )
+    ResponseEntity<ResultResponse> createMeal(@ModelAttribute MealCreateDto mealCreateDto);
+
+    @Operation(summary = "Meal 수정하기")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "Meal 수정에 성공했습니다.",
+                            content = @Content(schema = @Schema(implementation = ResultResponse.class))),
+                    @ApiResponse(responseCode = "400", description = "해당 id의 Meal이 없습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
+    ResponseEntity<ResultResponse> editMeal(@RequestBody MealEditDto mealEditDto);
+
+    @Operation(summary = "Meal 삭제하기")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "Meal 삭제에 성공했습니다.",
+                            content = @Content(schema = @Schema(implementation = ResultResponse.class))),
+                    @ApiResponse(responseCode = "400", description = "해당 id의 Meal이 없습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
+    ResponseEntity<ResultResponse> deleteMeal(@RequestParam("mealId") Long mealId);
+}

--- a/IAteIt/src/main/java/com/bnomad/IAteIt/domain/member/controller/MemberController.java
+++ b/IAteIt/src/main/java/com/bnomad/IAteIt/domain/member/controller/MemberController.java
@@ -13,7 +13,7 @@ import static com.bnomad.IAteIt.global.result.ResultCode.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/member")
-public class MemberController {
+public class MemberController implements MemberControllerSwagger {
 
     private final MemberService memberService;
 

--- a/IAteIt/src/main/java/com/bnomad/IAteIt/domain/member/controller/MemberControllerSwagger.java
+++ b/IAteIt/src/main/java/com/bnomad/IAteIt/domain/member/controller/MemberControllerSwagger.java
@@ -1,0 +1,22 @@
+package com.bnomad.IAteIt.domain.member.controller;
+
+import com.bnomad.IAteIt.domain.member.entity.dto.MemberEditRequest;
+import com.bnomad.IAteIt.global.result.ResultResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+@Tag(name = "Member", description = "Member 관련 API - Member 정보 불러오기/ 정보 변경 / 삭제")
+public interface MemberControllerSwagger {
+
+    @Operation(summary = "Member 정보 불러오기")
+    @ApiResponse()
+    ResponseEntity<ResultResponse> memberProfile();
+
+    @Operation(summary = "Member 정보 변경하기")
+    @ApiResponse()
+    ResponseEntity<ResultResponse> memberNicknameEdit(@ModelAttribute MemberEditRequest memberEditRequest);
+
+}

--- a/IAteIt/src/main/java/com/bnomad/IAteIt/domain/member/controller/MemberControllerSwagger.java
+++ b/IAteIt/src/main/java/com/bnomad/IAteIt/domain/member/controller/MemberControllerSwagger.java
@@ -1,22 +1,51 @@
 package com.bnomad.IAteIt.domain.member.controller;
 
 import com.bnomad.IAteIt.domain.member.entity.dto.MemberEditRequest;
+import com.bnomad.IAteIt.global.error.ErrorResponse;
 import com.bnomad.IAteIt.global.result.ResultResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
 
-@Tag(name = "Member", description = "Member 관련 API - Member 정보 불러오기/ 정보 변경 / 삭제")
+@Tag(name = "Member", description = "Member 관련 API - Member 정보 불러오기 / 정보 변경 / 삭제")
 public interface MemberControllerSwagger {
 
     @Operation(summary = "Member 정보 불러오기")
-    @ApiResponse()
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "멤버 정보를 불러왔습니다.",
+                            content = @Content(schema = @Schema(implementation = ResultResponse.class))),
+                    @ApiResponse(responseCode = "400", description = "해당 id의 멤버가 없습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
     ResponseEntity<ResultResponse> memberProfile();
 
     @Operation(summary = "Member 정보 변경하기")
-    @ApiResponse()
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "멤버 정보 변경에 성공했습니다.",
+                            content = @Content(schema = @Schema(implementation = ResultResponse.class))),
+                    @ApiResponse(responseCode = "400", description = "해당 id의 멤버가 없습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
     ResponseEntity<ResultResponse> memberNicknameEdit(@ModelAttribute MemberEditRequest memberEditRequest);
+
+    @Operation(summary = "Member 삭제")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "멤버를 삭제합니다.",
+                            content = @Content(schema = @Schema(implementation = ResultResponse.class))),
+                    @ApiResponse(responseCode = "400", description = "해당 id의 멤버가 없습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
+    ResponseEntity<ResultResponse> deleteMember();
 
 }

--- a/IAteIt/src/main/java/com/bnomad/IAteIt/domain/plate/controller/PlateController.java
+++ b/IAteIt/src/main/java/com/bnomad/IAteIt/domain/plate/controller/PlateController.java
@@ -13,7 +13,7 @@ import static com.bnomad.IAteIt.global.result.ResultCode.*;
 @RestController
 @RequestMapping("/api/v1/plate")
 @RequiredArgsConstructor
-public class PlateController {
+public class PlateController implements PlateControllerSwagger {
 
     private final PlateService plateService;
 

--- a/IAteIt/src/main/java/com/bnomad/IAteIt/domain/plate/controller/PlateControllerSwagger.java
+++ b/IAteIt/src/main/java/com/bnomad/IAteIt/domain/plate/controller/PlateControllerSwagger.java
@@ -1,0 +1,43 @@
+package com.bnomad.IAteIt.domain.plate.controller;
+
+import com.bnomad.IAteIt.domain.plate.entity.dto.PlateAddDto;
+import com.bnomad.IAteIt.global.error.ErrorResponse;
+import com.bnomad.IAteIt.global.result.ResultResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestParam;
+
+
+@Tag(name = "Plate", description = "Plate 추가 / 삭제")
+public interface PlateControllerSwagger {
+
+    @Operation(summary = "Plate 추가하기")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "Plate 추가에 성공했습니다.",
+                            content = @Content(schema = @Schema(implementation = ResultResponse.class))),
+                    @ApiResponse(responseCode = "400", description = "해당 Plate가 추가될 Meal의 id가 없습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
+    ResponseEntity<ResultResponse> addPlate(@ModelAttribute PlateAddDto plateAddDto);
+
+    @Operation(summary = "Plate 삭제하기")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "Plate 삭제에 성공했습니다.",
+                            content = @Content(schema = @Schema(implementation = ResultResponse.class))),
+                    @ApiResponse(responseCode = "400", description = "해당 id의 Plate가 없습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "400", description = "Plate id에 해당하는 Meal이 없습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
+    ResponseEntity<ResultResponse> deletePlate(@RequestParam("plateId") Long plateId);
+}

--- a/IAteIt/src/main/java/com/bnomad/IAteIt/domain/report/controller/ReportController.java
+++ b/IAteIt/src/main/java/com/bnomad/IAteIt/domain/report/controller/ReportController.java
@@ -13,7 +13,7 @@ import static com.bnomad.IAteIt.global.result.ResultCode.REPORT_CREATE_SUCCESS;
 @RestController
 @RequestMapping("/api/v1/report")
 @RequiredArgsConstructor
-public class ReportController {
+public class ReportController implements ReportControllerSwagger {
 
     private final ReportService reportService;
 

--- a/IAteIt/src/main/java/com/bnomad/IAteIt/domain/report/controller/ReportControllerSwagger.java
+++ b/IAteIt/src/main/java/com/bnomad/IAteIt/domain/report/controller/ReportControllerSwagger.java
@@ -1,0 +1,31 @@
+package com.bnomad.IAteIt.domain.report.controller;
+
+import com.bnomad.IAteIt.domain.report.entity.dto.ReportRequestDto;
+import com.bnomad.IAteIt.global.error.ErrorResponse;
+import com.bnomad.IAteIt.global.result.ResultResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+
+@Tag(name = "Report", description = "Report 보내기")
+public interface ReportControllerSwagger {
+
+    @Operation(summary = "Report 보내기")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "Report를 보냅니다.",
+                        content = @Content(schema = @Schema(implementation = ResultResponse.class))),
+                    @ApiResponse(responseCode = "400", description = "Report 전송에 실패했습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "400", description = "해당 id의 Meal이 없습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
+    ResponseEntity<ResultResponse> report(@RequestBody ReportRequestDto reportRequestDto);
+}

--- a/IAteIt/src/main/java/com/bnomad/IAteIt/global/auth/WebSecurityConfig.java
+++ b/IAteIt/src/main/java/com/bnomad/IAteIt/global/auth/WebSecurityConfig.java
@@ -83,14 +83,15 @@ public class WebSecurityConfig {
 
                 .authorizeHttpRequests(auth ->
                                 auth
-//                                        .requestMatchers(HttpMethod.POST, "/api/public/**")
-//                                        .permitAll()
                                         .requestMatchers("/api/v1/join")
                                         .permitAll()
-
+                                        .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**")
+                                        .permitAll()
                                         .anyRequest()
                                         .authenticated()
-                )
+                );
+
+        http
                 .oauth2Login(oauth2 ->
                         // oauth2 인증이 끝나면 잡아가는 포인트
                         oauth2
@@ -100,12 +101,14 @@ public class WebSecurityConfig {
                                 )
                                 // 성공하면, jwt 발급해주는 역할
                                 .successHandler(customAuthenticationHandler())
-                )
+                );
 
-                // UsernamePasswordAuthenticationFileter에 들어가기 전 JwtAuthenticationFilter를 실행하겠습니다~
+        // UsernamePasswordAuthenticationFileter에 들어가기 전 JwtAuthenticationFilter를 실행하겠습니다~
+        http
                 .addFilterBefore(
                         new JwtAuthenticationFilter(jwtProvider, jwtUtil), UsernamePasswordAuthenticationFilter.class
                 );
+
 
         return http.build();
     }

--- a/IAteIt/src/main/java/com/bnomad/IAteIt/global/auth/controller/LoginController.java
+++ b/IAteIt/src/main/java/com/bnomad/IAteIt/global/auth/controller/LoginController.java
@@ -13,7 +13,7 @@ import static com.bnomad.IAteIt.global.result.ResultCode.*;
 @RestController
 @RequestMapping("/api/v1/join")
 @RequiredArgsConstructor
-public class LoginController {
+public class LoginController implements LoginControllerSwagger {
 
     private final LoginService loginService;
 

--- a/IAteIt/src/main/java/com/bnomad/IAteIt/global/auth/controller/LoginController.java
+++ b/IAteIt/src/main/java/com/bnomad/IAteIt/global/auth/controller/LoginController.java
@@ -18,12 +18,6 @@ public class LoginController {
     private final LoginService loginService;
 
 
-    @GetMapping("/test")
-    public String joinTest() {
-        return "login";
-    }
-
-
     /**
      * oauth2: accessToken을 헤더에 포함해 리턴
      * accessToken을 활용해 -> 닉네임, 프로필이미지 -> 서비스회원가입

--- a/IAteIt/src/main/java/com/bnomad/IAteIt/global/auth/controller/LoginControllerSwagger.java
+++ b/IAteIt/src/main/java/com/bnomad/IAteIt/global/auth/controller/LoginControllerSwagger.java
@@ -1,0 +1,32 @@
+package com.bnomad.IAteIt.global.auth.controller;
+
+import com.bnomad.IAteIt.global.auth.dto.JoinRequestDto;
+import com.bnomad.IAteIt.global.error.ErrorResponse;
+import com.bnomad.IAteIt.global.result.ResultResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+@Tag(name = "Login", description = "최초 로그인 / OAuth2 로그인")
+public interface LoginControllerSwagger {
+
+    @Operation(summary = "최초 로그인 / OAuth2 로그인",
+    description = "최초 로그인 혹은 재로그인으로 토큰 발급시에만 사용해주세요.")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "Member 로그인에 성공했습니다.",
+                        content = @Content(schema = @Schema(implementation = ResultResponse.class))),
+                    @ApiResponse(responseCode = "400", description = "중복된 nickname입니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+
+            }
+    )
+    ResponseEntity<ResultResponse> join(@ModelAttribute JoinRequestDto joinRequestDto);
+
+}

--- a/IAteIt/src/main/java/com/bnomad/IAteIt/global/auth/filter/JwtAuthenticationFilter.java
+++ b/IAteIt/src/main/java/com/bnomad/IAteIt/global/auth/filter/JwtAuthenticationFilter.java
@@ -26,18 +26,17 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
-        // 헤더에서 JWT 를 추출
-        String token = jwtProvider.resolveToken(request);
 
-        // 유효한 토큰인지 확인
-        if (token != null && jwtProvider.validateToken(token)) {
-            // 토큰이 유효하면 토큰으로부터 유저 정보를 받아옵니다.
-            Authentication authentication = jwtProvider.getAuthentication(token);
-            // SecurityContext 에 Authentication 객체를 저장합니다. -> JwtUtil에서 활용하여 User 객체 접근을 빠르고 쉽게 가능하게 함
-            SecurityContextHolder.getContext().setAuthentication(authentication);
-        } else {
-            System.out.println("token = 토큰 값이 없어서 return 되는 중..." );
+        if (request.getRequestURI().contains("/api/")) {
+            String token = jwtProvider.resolveToken(request);
+            if (token != null && jwtProvider.validateToken(token)) {
+                Authentication authentication = jwtProvider.getAuthentication(token);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            } else {
+                System.out.println("token = 토큰 값이 없어서 return 되는 중..." );
+            }
         }
+
         filterChain.doFilter(request, response);
     }
 

--- a/IAteIt/src/main/java/com/bnomad/IAteIt/global/config/SwaggerConfig.java
+++ b/IAteIt/src/main/java/com/bnomad/IAteIt/global/config/SwaggerConfig.java
@@ -1,0 +1,24 @@
+package com.bnomad.IAteIt.global.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(getInfo());
+    }
+
+    public Info getInfo() {
+        Info info = new Info();
+        info.setTitle("IAteIt");
+        info.setDescription("IAteIt의 API 스펙 알아보기");
+        return info;
+    }
+
+}

--- a/IAteIt/src/main/java/com/bnomad/IAteIt/global/config/SwaggerConfig.java
+++ b/IAteIt/src/main/java/com/bnomad/IAteIt/global/config/SwaggerConfig.java
@@ -1,23 +1,44 @@
 package com.bnomad.IAteIt.global.config;
 
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.ArrayList;
+import java.util.List;
+
+@SecurityScheme(
+        type = SecuritySchemeType.APIKEY,
+        name = "Authorization",
+        description = "access Token을 입력해주세요.",
+        in = SecuritySchemeIn.HEADER)
 @Configuration
 public class SwaggerConfig {
 
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
-                .info(getInfo());
+                .addServersItem(new Server().url("/"))
+                .info(getInfo())
+                .security(getSecurityRequirement());
+    }
+
+    private List<SecurityRequirement> getSecurityRequirement() {
+        List<SecurityRequirement> requirements = new ArrayList<>();
+        requirements.add(new SecurityRequirement().addList("Authorization"));
+        return requirements;
     }
 
     public Info getInfo() {
         Info info = new Info();
         info.setTitle("IAteIt");
-        info.setDescription("IAteIt의 API 스펙 알아보기");
+        info.setDescription("IAteIt API를 알아보자!");
         return info;
     }
 


### PR DESCRIPTION
## 관련 이슈
- #3 

## 작업 내용
- 구현되어 있는 API들의 Swagger 문서 작성을 했습니다.
- Controller에 의존하는 코드보다 interface로 class와 분리해 작성했습니다.
- `{baseURL}/swagger-ui.html` 로 접근 가능합니다

- Swagger 접근에는 Security의 활성화를 막기위해 `Jwt Filter`에서 `/api/` URI가 아닌 URL들을 필터링합니다

## 스크린샷(UX의 경우 gif)
<img src="https://github.com/Bnomad-space/IAteIt-Server/assets/72736657/554d02a4-bcfe-466e-b284-dd37aa940274" width="600">

## Reference
- Swagger 구현하며 JWT의 HTTP header 추가하는 방법을 정리해서 블로그 작성도 했답니다 ㅎ
- [Swagger 구현](https://driveitlikeyoustoleitt.tistory.com/entry/IAteIt-Swagger-Springdoc-openapi3-커스텀-Header-추가하기)
